### PR TITLE
Fix migrations list bug

### DIFF
--- a/src/db/migrations.js
+++ b/src/db/migrations.js
@@ -42,14 +42,13 @@ module.exports.init = async (db) => {
 //
 module.exports.initmigrations = async (db) => {
   const sql = db.driver.dialect.createMigrationsTable;
-  await await db.query(sql);
+  await db.query(sql);
 };
 
 //
 module.exports.list = async (db) => {
   await module.exports.initmigrations(db);
   const sql = db.driver.dialect.listMigrations;
-  return db.query(sql);
   return await db.query(sql);
 };
 


### PR DESCRIPTION
## Summary
- remove duplicate return and double await in migrations helpers

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bec9926f0832387cb5678746d50c2